### PR TITLE
Use `websearch_to_tsquery` to relax query syntax on searches

### DIFF
--- a/lib/elite_investigations/elite.ex
+++ b/lib/elite_investigations/elite.ex
@@ -160,8 +160,8 @@ defmodule EliteInvestigations.Elite do
       from s in Story,
       join: q in subquery(sub_query),
       on: q.s_nid == s.nid,
-      where: fragment("? @@ to_tsquery(?)", q.document, ^search_text),
-      order_by: fragment("ts_rank(?, to_tsquery(?)) DESC", q.document, ^search_text)
+      where: fragment("? @@ websearch_to_tsquery(?)", q.document, ^search_text),
+      order_by: fragment("ts_rank(?, websearch_to_tsquery(?)) DESC", q.document, ^search_text)
 
     Repo.all(query)
   end

--- a/lib/elite_investigations_web/templates/story/blankslate.html.slime
+++ b/lib/elite_investigations_web/templates/story/blankslate.html.slime
@@ -1,2 +1,5 @@
 .blankslate
-  h3 = gettext "No stories for you to see here"
+  = if @search_text == "" do
+    h3 = gettext "No stories for you to see here"
+  - else
+    h3 = gettext "No matching stories found"

--- a/lib/elite_investigations_web/templates/story/index.html.slime
+++ b/lib/elite_investigations_web/templates/story/index.html.slime
@@ -1,6 +1,6 @@
 form.mb-3
   .input-group
-    input.form-control#search-text type="text" placeholder="Search" aria-label="Search" value="#{@search_text}"
+    input.form-control#search-text name="q" type="text" placeholder="Search" aria-label="Search" value="#{@search_text}"
     input#search-type type="hidden" value="galnet"
     span.input-group-button
       button.btn#search-button type="button" aria-label="Execute search"


### PR DESCRIPTION
Fixes #7 